### PR TITLE
Change the copyright notice globally on the mogwai-project

### DIFF
--- a/404
+++ b/404
@@ -51,7 +51,7 @@
 </main>
 
 <footer role="contentinfo">
-  <p class="copyright">The content for this site is <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>. The code for this site is <a href="https://opensource.org/license/mit/">MIT</a>.</p>
+  <p class="copyright">The content for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/CC-BY-SA-4.0-LICENSE.md">CC-BY-SA</a>. The code for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/MIT-LICENSE.md">MIT</a>.</p>
 </footer>
 
     </div>

--- a/archive/2023/my-linux-rigs-for-development
+++ b/archive/2023/my-linux-rigs-for-development
@@ -91,7 +91,7 @@
 </main>
 
 <footer role="contentinfo">
-  <p class="copyright">The content for this site is <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>. The code for this site is <a href="https://opensource.org/license/mit/">MIT</a>.</p>
+  <p class="copyright">The content for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/CC-BY-SA-4.0-LICENSE.md">CC-BY-SA</a>. The code for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/MIT-LICENSE.md">MIT</a>.</p>
 </footer>
 
     </div>

--- a/archive/2023/on-becoming-shell-literate
+++ b/archive/2023/on-becoming-shell-literate
@@ -70,7 +70,7 @@
 </main>
 
 <footer role="contentinfo">
-  <p class="copyright">The content for this site is <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>. The code for this site is <a href="https://opensource.org/license/mit/">MIT</a>.</p>
+  <p class="copyright">The content for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/CC-BY-SA-4.0-LICENSE.md">CC-BY-SA</a>. The code for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/MIT-LICENSE.md">MIT</a>.</p>
 </footer>
 
     </div>

--- a/archive/2023/switching-from-windows-to-linux
+++ b/archive/2023/switching-from-windows-to-linux
@@ -77,7 +77,7 @@
 </main>
 
 <footer role="contentinfo">
-  <p class="copyright">The content for this site is <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>. The code for this site is <a href="https://opensource.org/license/mit/">MIT</a>.</p>
+  <p class="copyright">The content for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/CC-BY-SA-4.0-LICENSE.md">CC-BY-SA</a>. The code for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/MIT-LICENSE.md">MIT</a>.</p>
 </footer>
 
     </div>

--- a/contact
+++ b/contact
@@ -48,7 +48,7 @@
 </main>
 
 <footer role="contentinfo">
-  <p class="copyright">The content for this site is <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>. The code for this site is <a href="https://opensource.org/license/mit/">MIT</a>.</p>
+  <p class="copyright">The content for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/CC-BY-SA-4.0-LICENSE.md">CC-BY-SA</a>. The code for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/MIT-LICENSE.md">MIT</a>.</p>
 </footer>
 
     </div>

--- a/essays
+++ b/essays
@@ -66,7 +66,7 @@
 </main>
 
 <footer role="contentinfo">
-  <p class="copyright">The content for this site is <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>. The code for this site is <a href="https://opensource.org/license/mit/">MIT</a>.</p>
+  <p class="copyright">The content for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/CC-BY-SA-4.0-LICENSE.md">CC-BY-SA</a>. The code for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/MIT-LICENSE.md">MIT</a>.</p>
 </footer>
 
     </div>

--- a/readme
+++ b/readme
@@ -56,7 +56,7 @@
 </main>
 
 <footer role="contentinfo">
-  <p class="copyright">The content for this site is <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>. The code for this site is <a href="https://opensource.org/license/mit/">MIT</a>.</p>
+  <p class="copyright">The content for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/CC-BY-SA-4.0-LICENSE.md">CC-BY-SA</a>. The code for this site is <a https://github.com/DeafblindEngineer/mogwai-project/blob/main/MIT-LICENSE.md">MIT</a>.</p>
 </footer>
 
     </div>


### PR DESCRIPTION
## What?

I have changed the links for the copyright notice on the essays, contact, readme, 404, and three essays in the 2023 archive pages to link to the CC-BY-SA-4.0-LICENSE.md and MIT-LICENSE.md in the mogwai-project repository.

## Why?

I want to link to the licenses that I have 100% control over.

These changes complete the user login and account creation experience. See #JIRA-123 for more information.

## How?

I have change two links on each page in the footer for the copyright notice.
